### PR TITLE
Add source information

### DIFF
--- a/cmd/protoc-gen-openapi/generator/wellknown/schemas.go
+++ b/cmd/protoc-gen-openapi/generator/wellknown/schemas.go
@@ -23,31 +23,104 @@ import (
 func NewStringSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "string"}}}
+			Schema: &v3.Schema{
+				Type: "string",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.StringValue
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func NewBooleanSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "boolean"}}}
+			Schema: &v3.Schema{
+				Type: "boolean",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.BoolValue
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func NewBytesSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "string", Format: "bytes"}}}
+			Schema: &v3.Schema{
+				Type:   "string",
+				Format: "bytes",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.BytesValue
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func NewIntegerSchema(format string) *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "integer", Format: format}}}
+			Schema: &v3.Schema{
+				Type:   "integer",
+				Format: format,
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.Int64Value
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func NewNumberSchema(format string) *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "number", Format: format}}}
+			Schema: &v3.Schema{
+				Type:   "number",
+				Format: format,
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.DoubleValue
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func NewEnumSchema(enum_type *string, field protoreflect.FieldDescriptor) *v3.SchemaOrReference {
@@ -91,7 +164,22 @@ func NewGoogleApiHttpBodySchema() *v3.SchemaOrReference {
 func NewGoogleProtobufTimestampSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "string", Format: "date-time"}}}
+			Schema: &v3.Schema{
+				Type:   "string",
+				Format: "date-time",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.Timestamp
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // google.protobuf.Duration is serialized as a string
@@ -133,6 +221,16 @@ func NewGoogleProtobufDurationSchema() *v3.SchemaOrReference {
 				Type:        "string",
 				Pattern:     `^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$`,
 				Description: "Represents a a duration between -315,576,000,000s and 315,576,000,000s (around 10000 years). Precision is in nanoseconds. 1 nanosecond is represented as 0.000000001s",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.Duration
+`,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -156,21 +254,53 @@ func NewGoogleTypeDateTimeSchema() *v3.SchemaOrReference {
 func NewGoogleProtobufFieldMaskSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "string", Format: "field-mask"}}}
+			Schema: &v3.Schema{
+				Type:   "string",
+				Format: "field-mask",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.FieldMask
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // google.protobuf.Struct is equivalent to a JSON object
 func NewGoogleProtobufStructSchema() *v3.SchemaOrReference {
 	return &v3.SchemaOrReference{
 		Oneof: &v3.SchemaOrReference_Schema{
-			Schema: &v3.Schema{Type: "object"}}}
+			Schema: &v3.Schema{
+				Type: "object",
+				SpecificationExtension: []*v3.NamedAny{
+					{
+						Name: "x-fern-encoding",
+						Value: &v3.Any{
+							Yaml: `proto:
+  type: google.protobuf.Struct
+`,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // google.protobuf.Value is handled specially
 // See here for the details on the JSON mapping:
-//   https://developers.google.com/protocol-buffers/docs/proto3#json
+//
+//	https://developers.google.com/protocol-buffers/docs/proto3#json
+//
 // and here:
-//   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
+//
+//	https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
 func NewGoogleProtobufValueSchema(name string) *v3.NamedSchemaOrReference {
 	return &v3.NamedSchemaOrReference{
 		Name: name,
@@ -178,6 +308,16 @@ func NewGoogleProtobufValueSchema(name string) *v3.NamedSchemaOrReference {
 			Oneof: &v3.SchemaOrReference_Schema{
 				Schema: &v3.Schema{
 					Description: "Represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values.",
+					SpecificationExtension: []*v3.NamedAny{
+						{
+							Name: "x-fern-encoding",
+							Value: &v3.Any{
+								Yaml: `proto:
+  type: google.protobuf.Value
+`,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -186,7 +326,8 @@ func NewGoogleProtobufValueSchema(name string) *v3.NamedSchemaOrReference {
 
 // google.protobuf.Any is handled specially
 // See here for the details on the JSON mapping:
-//   https://developers.google.com/protocol-buffers/docs/proto3#json
+//
+//	https://developers.google.com/protocol-buffers/docs/proto3#json
 func NewGoogleProtobufAnySchema(name string) *v3.NamedSchemaOrReference {
 	return &v3.NamedSchemaOrReference{
 		Name: name,
@@ -213,6 +354,16 @@ func NewGoogleProtobufAnySchema(name string) *v3.NamedSchemaOrReference {
 					AdditionalProperties: &v3.AdditionalPropertiesItem{
 						Oneof: &v3.AdditionalPropertiesItem_Boolean{
 							Boolean: true,
+						},
+					},
+					SpecificationExtension: []*v3.NamedAny{
+						{
+							Name: "x-fern-encoding",
+							Value: &v3.Any{
+								Yaml: `proto:
+  type: google.protobuf.Any
+`,
+							},
 						},
 					},
 				},

--- a/cmd/protoc-gen-openapi/main.go
+++ b/cmd/protoc-gen-openapi/main.go
@@ -38,6 +38,7 @@ func main() {
 		CircularDepth:   flags.Int("depth", 2, "depth of recursion for circular messages"),
 		DefaultResponse: flags.Bool("default_response", true, `add default response. If "true", automatically adds a default response to operations which use the google.rpc.Status message. Useful if you use envoy or grpc-gateway to transcode as they use this type for their default error responses.`),
 		OutputMode:      flags.String("output_mode", "merged", `output generation mode. By default, a single openapi.yaml is generated at the out folder. Use "source_relative' to generate a separate '[inputfile].openapi.yaml' next to each '[inputfile].proto'.`),
+		SourceRoot:      flags.String("source_root", "", `root directory of the source Protobuf files. This is used to add source information to the openapi.yaml file.`),
 	}
 
 	opts := protogen.Options{


### PR DESCRIPTION
This updates the `protoc-gen-openapi` plugin to preserve source information (based on the `FileDescriptorProto` it's defined within). 

This also updates the well-known types to preserve an `x-fern-encoding` setting so we can more easily determine whether or not they're sourced from a well-known wrapper type. Note that additional work is likely required here to further distinguish between things like `Int64Value` and `Uint64Value`, which could influence the generated code in particular languages.