### PR TITLE
fix: dont serialize longs as strings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.17
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/cmd/protoc-gen-openapi/generator/reflector.go
+++ b/cmd/protoc-gen-openapi/generator/reflector.go
@@ -208,12 +208,10 @@ func (r *OpenAPIv3Reflector) schemaOrReferenceForField(field protoreflect.FieldD
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
-		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind:
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Fixed64Kind:
 		kindSchema = wk.NewIntegerSchema(kind.String())
-
-	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
-		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
-		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.EnumKind:
 		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fern-api/protoc-gen-openapi
 
-go 1.17
+go 1.20
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fern-api/protoc-gen-openapi
 
-go 1.12
+go 1.17
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
This is a common revert for forks of the protoc gen openapi, since the generated types from OpenAPI dont really match the proto wire format. 