### PR TITLE
Add release workflow to publish pre-built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
             "darwin/amd64"
             "darwin/arm64"
             "windows/amd64"
+            "windows/arm64"
           )
 
           for platform in "${platforms[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "^1.20"
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build binaries
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          BINARY=protoc-gen-openapi
+          MODULE=./cmd/protoc-gen-openapi
+
+          platforms=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+            "windows/amd64"
+          )
+
+          for platform in "${platforms[@]}"; do
+            GOOS="${platform%/*}"
+            GOARCH="${platform#*/}"
+            output="${BINARY}-${GOOS}-${GOARCH}"
+            if [ "$GOOS" = "windows" ]; then
+              output="${output}.exe"
+            fi
+            echo "Building ${output}..."
+            GOOS=$GOOS GOARCH=$GOARCH go build -trimpath -ldflags="-s -w" -o "dist/${output}" $MODULE
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     name: Build and Release
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Build binaries
         run: |


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds cross-platform `protoc-gen-openapi` binaries and publishes them as GitHub Release assets when a version tag (`v*`) is pushed.

**Motivation:** Currently, consumers must install Go and compile from source via `go install` on every CI run, which takes ~31s. Pre-built binaries allow direct download instead (~1-2s).

**Platforms:** linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64

**Binary naming:** `protoc-gen-openapi-{os}-{arch}[.exe]`

## Review & Testing Checklist for Human
- [x] This workflow cannot be tested via PR CI — it only triggers on tag push. After merging, push a new tag (e.g. `v0.1.13`) to verify it creates a release with the expected binary assets.
- [x] Verify the Go version constraint (`^1.20`) is still appropriate for this project's `go.mod`.
- [x] Consider whether `windows/arm64` should be added to the platform list.

### Notes
- The `VERSION` variable is captured from `GITHUB_REF_NAME` but not currently injected into the binary via ldflags. This is fine since the binary doesn't read a version from ldflags, but could be wired up later if needed.
- No SHA256 checksums file is generated. Could be added in a follow-up if desired.

Link to Devin session: https://app.devin.ai/sessions/9aa3a5abd77d4e069bcfade48423e986
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/protoc-gen-openapi/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
